### PR TITLE
fix a file descriptor leak

### DIFF
--- a/src/zc/resumelb/tests.py
+++ b/src/zc/resumelb/tests.py
@@ -401,6 +401,27 @@ Now, somehow, we switch back to version 1.  Not sure how:
     9
     """
 
+def worker_closes_socket():
+    """
+
+Disconnecting from a worker does not leak a file descriptor.
+
+    >>> worker = zc.resumelb.worker.Worker(
+    ...   zc.resumelb.tests.app(), ('127.0.0.1', 0))
+    >>> import gevent
+    >>> import gevent.socket
+    >>> sock = gevent.socket.create_connection(worker.addr)
+
+
+    >>> gevent.sleep(0.1)
+    >>> conn = list(worker.connections)[0]
+    >>> sock.close()
+    >>> gevent.sleep(0.1)
+
+    >>> conn.socket # doctest: +ELLIPSIS
+    <socket at 0x... fileno=[Errno 9] Bad file descriptor>
+    """
+
 def test_classifier(env):
     return "yup, it's a test"
 

--- a/src/zc/resumelb/util.py
+++ b/src/zc/resumelb/util.py
@@ -201,6 +201,7 @@ class Worker:
         gevent.Greenlet.spawn(writer, writeq, socket, self)
         self.put = writeq.put
         self.is_connected = True
+        self.socket = socket
         return self.readers
 
     def __len__(self):
@@ -225,6 +226,7 @@ class Worker:
         self.is_connected = False
         for put in self.readers.itervalues():
             put(None)
+        self.socket.close()
 
         self.put = self.put_disconnected
 


### PR DESCRIPTION
Disconnecting from a Worker leaks a file descriptor, because the worker never calls `close` on its socket.
